### PR TITLE
Fixed the bug

### DIFF
--- a/lib/common/settings_notifier.dart
+++ b/lib/common/settings_notifier.dart
@@ -5,17 +5,25 @@ class SettingsModel extends ChangeNotifier {
   String language = "en";
   String units = "metric";
 
-  setLanguage(String newLanguage) async {
+  /// [setPref] is true by default
+  setLanguage(String newLanguage, [bool? setPref]) async {
+    setPref ??= true;
     language = newLanguage;
-    SharedPreferences prefs = await SharedPreferences.getInstance();
-    await prefs.setString("language", language);
+    if (setPref) {
+      SharedPreferences prefs = await SharedPreferences.getInstance();
+      await prefs.setString("language", language);
+    }
     notifyListeners();
   }
 
-  setUnits(String newUnits) async {
+  /// [setPref] is true by default
+  setUnits(String newUnits, [bool? setPref]) async {
+    setPref ??= true;
     units = newUnits;
-    SharedPreferences prefs = await SharedPreferences.getInstance();
-    await prefs.setString("units", units);
+    if (setPref) {
+      SharedPreferences prefs = await SharedPreferences.getInstance();
+      await prefs.setString("units", units);
+    }
     notifyListeners();
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -29,8 +29,8 @@ class _MyAppState extends State<MyApp> {
     var units = prefs.getString("units");
 
     SettingsModel provider = Provider.of<SettingsModel>(context, listen: false);
-    if (language != null) provider.setLanguage(language);
-    if (units != null) provider.setLanguage(units);
+    if (language != null) provider.setLanguage(language, false);
+    if (units != null) provider.setUnits(units, false);
   }
 
   @override

--- a/lib/mainPages/settings.dart
+++ b/lib/mainPages/settings.dart
@@ -50,6 +50,7 @@ class _SettingsState extends State<Settings> {
                 style: const TextStyle(fontSize: 18.0),
               ),
               onChanged: (val) {
+                print(val);
                 settingsProvider.setLanguage(val);
               },
             ),
@@ -64,6 +65,7 @@ class _SettingsState extends State<Settings> {
                 style: const TextStyle(fontSize: 18.0),
               ),
               onChanged: (val) {
+                print(val);
                 settingsProvider.setUnits(val);
               },
             ),


### PR DESCRIPTION
This should fix issue #4. It was setting the language variable to the units variable when it was initializing the settings provider. The issue is now solved.